### PR TITLE
✨ feat: モックUIの静的HTMLとCSSを追加

### DIFF
--- a/mock/index.html
+++ b/mock/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Mock - Local Markdown Memo</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app">
+      <aside class="sidebar" data-theme="dark">
+        <header class="sidebar__header">
+          <div class="sidebar__title-group">
+            <h1 class="sidebar__title">メモ</h1>
+            <p class="sidebar__subtitle">ひらめきをすぐに記録</p>
+          </div>
+          <div class="sidebar__header-actions">
+            <span class="badge" aria-live="polite">2</span>
+            <button class="icon-button icon-button--primary" title="新規メモを作成" aria-label="新規メモを作成" type="button">
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+              <span class="visually-hidden">新しいメモ</span>
+            </button>
+          </div>
+        </header>
+
+        <ul class="note-list" aria-label="メモ一覧">
+          <li class="note-list__item note-list__item--active" tabindex="0">
+            <p class="note-list__title">新しいメモ</p>
+            <div class="note-list__footer">
+              <span class="note-list__meta">更新: 2025/12/22 23:18:53</span>
+              <button class="note-list__delete" type="button" aria-label="このメモを削除">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                </svg>
+              </button>
+            </div>
+          </li>
+
+          <li class="note-list__item" tabindex="0">
+            <p class="note-list__title">あいうえさっっっっっっ…</p>
+            <div class="note-list__footer">
+              <span class="note-list__meta">更新: 2025/10/04 20:26:01</span>
+              <button class="note-list__delete" type="button" aria-label="このメモを削除">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <polyline points="3 6 5 6 21 6" />
+                  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                  <path d="M10 11v6" />
+                  <path d="M14 11v6" />
+                  <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+                </svg>
+              </button>
+            </div>
+          </li>
+        </ul>
+      </aside>
+
+      <main class="editor" data-theme="dark" aria-live="polite">
+        <div class="editor__header">
+          <div class="editor__title-wrapper">
+            <input class="editor__title-input" type="text" value="新しいメモ" aria-label="メモタイトル" />
+            <span class="editor__meta">最終更新: 2025/12/22 23:18:53</span>
+          </div>
+
+          <div class="editor__actions">
+            <button class="icon-button" title="メモを削除" aria-label="メモを削除" type="button">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <polyline points="3 6 5 6 21 6" />
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+                <path d="M10 11v6" />
+                <path d="M14 11v6" />
+                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <textarea class="editor__textarea" aria-label="メモ本文">水２００
+ソーダ３００
+ミックス４００
+ミルク６００
+１３９００
+13900
+11200
+18600gh</textarea>
+
+        <div class="editor__status" aria-live="polite">
+          <span class="status-indicator" aria-hidden="true"></span>
+          <span class="editor__status-text">編集中</span>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/mock/styles.css
+++ b/mock/styles.css
@@ -1,0 +1,260 @@
+:root {
+  color-scheme: dark;
+  --bg: #050b17;
+  --bg-2: #0b1020;
+  --panel: rgba(17, 24, 39, 0.78);
+  --panel-2: rgba(11, 17, 32, 0.9);
+  --border: rgba(148, 163, 184, 0.24);
+  --border-soft: rgba(148, 163, 184, 0.16);
+  --text: rgba(226, 232, 240, 0.92);
+  --text-muted: rgba(148, 163, 184, 0.78);
+  --primary: #3b82f6;
+  --primary-soft: rgba(59, 130, 246, 0.22);
+  --primary-soft-2: rgba(96, 165, 250, 0.18);
+  --danger: #f87171;
+  --shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(900px 520px at 20% 0%, rgba(59, 130, 246, 0.14), transparent 60%),
+    radial-gradient(720px 520px at 70% 30%, rgba(14, 165, 233, 0.1), transparent 55%),
+    linear-gradient(120deg, var(--bg), var(--bg-2));
+  color: var(--text);
+}
+
+.app {
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 340px 1fr;
+}
+
+.sidebar {
+  padding: 22px 22px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: linear-gradient(180deg, rgba(11, 17, 32, 0.96), rgba(8, 12, 24, 0.96));
+  border-right: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.sidebar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.sidebar__title-group {
+  min-width: 0;
+}
+
+.sidebar__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.sidebar__subtitle {
+  margin: 8px 0 0;
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.sidebar__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.badge {
+  min-width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+  font-size: 12px;
+  font-weight: 700;
+  background: rgba(59, 130, 246, 0.26);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.note-list {
+  list-style: none;
+  padding: 0;
+  margin: 4px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.note-list__item {
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 14px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: rgba(15, 23, 42, 0.22);
+}
+
+.note-list__item--active {
+  background: rgba(96, 165, 250, 0.18);
+}
+
+.note-list__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+  color: rgba(226, 232, 240, 0.94);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.note-list__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.note-list__meta {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.note-list__delete {
+  border: none;
+  background: transparent;
+  padding: 6px;
+  border-radius: 10px;
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.note-list__delete svg {
+  display: block;
+}
+
+.icon-button {
+  border: none;
+  background: transparent;
+  padding: 8px;
+  border-radius: 10px;
+  color: rgba(226, 232, 240, 0.82);
+}
+
+.icon-button svg {
+  display: block;
+}
+
+.icon-button--primary {
+  width: 44px;
+  height: 44px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.22);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+.editor {
+  padding: 30px 34px;
+  background: linear-gradient(180deg, rgba(17, 24, 39, 0.86), rgba(17, 24, 39, 0.64));
+}
+
+.editor__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.editor__title-wrapper {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.editor__title-input {
+  width: 100%;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  padding: 16px 18px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.58);
+  color: rgba(226, 232, 240, 0.96);
+  outline: none;
+}
+
+.editor__meta {
+  font-size: 12px;
+  color: rgba(148, 163, 184, 0.78);
+}
+
+.editor__actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.editor__textarea {
+  margin-top: 18px;
+  width: 100%;
+  height: calc(100vh - 220px);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(15, 23, 42, 0.56);
+  color: rgba(226, 232, 240, 0.94);
+  padding: 22px 22px;
+  resize: none;
+  font-family: "JetBrains Mono", "SFMono-Regular", Consolas, ui-monospace, monospace;
+  font-size: 16px;
+  line-height: 1.65;
+  outline: none;
+}
+
+.editor__status {
+  margin-top: 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: rgba(148, 163, 184, 0.8);
+  font-size: 12px;
+}
+
+.status-indicator {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.6);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
- メモアプリのデザインモックとして静的HTMLファイルを作成
- ダークテーマのUIスタイルシートを実装
- サイドバーにメモ一覧表示レイアウトを追加
- エディタ領域にタイトル入力とテキストエリアを配置
- アクセシビリティ対応のARIA属性とスクリーンリーダー用テキストを実装
- グラデーション背景とガラスモーフィズム風のパネルデ