### PR TITLE
fix: メモ切替時にプレビューが更新されない問題を修正

### DIFF
--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -17,6 +17,7 @@ import {
 } from "./state.js";
 import { elements } from "./dom.js";
 import { renderNoteList, updateEditor, setStatus, updateActiveNoteMeta } from "./render.js";
+import { renderPreviewPanel } from "./preview_panel.js";
 
 const AUTO_SAVE_DELAY = 400;
 let autoSaveTimeout = null;
@@ -85,6 +86,10 @@ export function renderApp() {
     activeNoteId: getActiveNoteId(),
   });
   updateEditor(getActiveNote(), notes.length);
+  const { previewPanelEl } = elements;
+  if (previewPanelEl && !previewPanelEl.hidden) {
+    renderPreviewPanel();
+  }
 }
 
 function handleCreateNote() {

--- a/extension/src/preview.js
+++ b/extension/src/preview.js
@@ -3,7 +3,7 @@ import { initializeTheme } from "./theme.js";
 import { initializeState, getActiveNote } from "./state.js";
 import { attachEventListeners, renderApp } from "./events.js";
 import { setStatus } from "./render.js";
-import { renderPreview } from "./preview_renderer.js";
+import { renderPreviewPanel } from "./preview_panel.js";
 
 // プレビュータブであることを明示
 document.body.dataset.previewTab = "true";
@@ -217,17 +217,6 @@ function bindLivePreview() {
       renderPreviewPanel();
     }
   });
-}
-
-export function renderPreviewPanel() {
-  // 現在のメモ本文をMarkdownとして描画し、Mermaidブロックがあれば図にする
-  // プレビュー切替の瞬間に state へ反映前の入力があるため、textarea の値を優先する
-  const editorText = elements.noteBodyEl?.value;
-  const note = getActiveNote();
-  const text = (typeof editorText === "string" ? editorText : note?.body) || "";
-  const { previewContainerEl } = elements;
-  if (!previewContainerEl) return;
-  renderPreview({ text, target: previewContainerEl });
 }
 
 init();

--- a/extension/src/preview_panel.js
+++ b/extension/src/preview_panel.js
@@ -1,0 +1,15 @@
+import { elements } from "./dom.js";
+import { getActiveNote } from "./state.js";
+import { renderPreview } from "./preview_renderer.js";
+
+export function renderPreviewPanel() {
+  // 現在のメモ本文をMarkdownとして描画し、Mermaidブロックがあれば図にする
+  // プレビュー切替の瞬間に state へ反映前の入力があるため、textarea の値を優先する
+  const editorText = elements.noteBodyEl?.value;
+  const note = getActiveNote();
+  const text = (typeof editorText === "string" ? editorText : note?.body) || "";
+  const { previewContainerEl } = elements;
+  if (!previewContainerEl) return;
+  renderPreview({ text, target: previewContainerEl });
+}
+


### PR DESCRIPTION
プレビュー表示中にメモを切り替えてもプレビューが更新されない問題を修正しました。

- renderApp() 実行時、プレビュー表示中ならプレビューパネルを再描画
- プレビュー描画処理を preview_panel.js に共通化