### PR TITLE
fix: インラインコードの二重エスケープ＆タブオープン直前の即時保存

### DIFF
--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -193,9 +193,17 @@ function handleSortToggle() {
 }
 
 function handlePreviewOpen() {
-  // タブ側は拡張の保存領域から直接ロードするため、payload受け渡しは不要。
-  const url = chrome.runtime.getURL("src/preview.html");
-  openInNewTab(url, "プレビューを開けませんでした");
+  // タブ側は拡張の保存領域から直接ロードするため、最新状態を先に保存してから開く。
+  (async () => {
+    try {
+      await persistNow();
+    } catch (error) {
+      console.error("タブを開く前の保存に失敗しました", error);
+      setStatus("idle", "保存に失敗しました");
+    }
+    const url = chrome.runtime.getURL("src/preview.html");
+    openInNewTab(url, "プレビューを開けませんでした");
+  })();
 }
 
 function handleOpenDocs() {
@@ -690,4 +698,28 @@ function scheduleAutoSave() {
       setStatus("idle", "編集中");
     }, 1500);
   }, AUTO_SAVE_DELAY);
+}
+
+async function persistNow() {
+  // タブを開く等の「即時保存」が必要な場面用（遅延保存をキャンセルして保存する）
+  if (autoSaveTimeout) {
+    clearTimeout(autoSaveTimeout);
+    autoSaveTimeout = null;
+  }
+  if (statusResetTimeout) {
+    clearTimeout(statusResetTimeout);
+    statusResetTimeout = null;
+  }
+
+  const { noteTitleEl, noteBodyEl } = elements;
+  if (noteTitleEl && noteBodyEl) {
+    updateActiveNote({ title: noteTitleEl.value, body: noteBodyEl.value });
+  }
+
+  setStatus("saving", "保存中…");
+  await persistState();
+  setStatus("saved", "保存しました");
+  statusResetTimeout = setTimeout(() => {
+    setStatus("idle", "編集中");
+  }, 1500);
 }

--- a/extension/src/markdown.js
+++ b/extension/src/markdown.js
@@ -28,10 +28,24 @@ export function renderMarkdown(text) {
       .replace(/>/g, "&gt;");
 
   const formatInline = (str) => {
-    let escaped = escapeHtml(str);
-    escaped = escaped.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeHtml(code)}</code>`);
+    const codeSpans = [];
+    const placeholderPrefix = "@@INLINE_CODE_SPAN_";
+    const placeholderSuffix = "@@";
+
+    const processed = String(str || "").replace(/`([^`]+)`/g, (_, code) => {
+      const idx = codeSpans.length;
+      codeSpans.push(String(code ?? ""));
+      return `${placeholderPrefix}${idx}${placeholderSuffix}`;
+    });
+
+    let escaped = escapeHtml(processed);
     escaped = escaped.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
     escaped = escaped.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+
+    for (let i = 0; i < codeSpans.length; i++) {
+      const token = `${placeholderPrefix}${i}${placeholderSuffix}`;
+      escaped = escaped.replaceAll(token, `<code>${escapeHtml(codeSpans[i])}</code>`);
+    }
     return escaped;
   };
 


### PR DESCRIPTION
Fixes #5
Fixes #7

## 変更内容
- Markdownのインラインコードをプレースホルダー方式で処理し、二重エスケープとコード内装飾の誤適用を防止
- 「タブを開く」クリック時に遅延保存をキャンセルして即時保存し、タブ側が最新内容を読むように修正
