### PR TITLE
enhance: メモ一覧のEnter/Space選択 + docs閉じるのフォールバック

### DIFF
--- a/extension/src/docs.js
+++ b/extension/src/docs.js
@@ -2,7 +2,26 @@ function init() {
   // 仕様書ページ（docs.html）内の閉じるボタン
   const closeBtn = document.getElementById("close");
   closeBtn?.addEventListener("click", () => {
-    window.close();
+    // タブで開かれた場合は window.close() が効かないことがあるため、フォールバックを用意する
+    try {
+      window.close();
+    } catch (e) {
+      // ignore
+    }
+
+    // closeが失敗した場合のフォールバック（戻る or 案内表示）
+    setTimeout(() => {
+      if (window.closed) return;
+      try {
+        if (typeof history !== "undefined" && history.length > 1) {
+          history.back();
+          return;
+        }
+      } catch (e) {
+        // ignore
+      }
+      showNotice("このページは自動で閉じられません。ブラウザの「×」で閉じてください。");
+    }, 100);
   });
 
   const contentEl = document.getElementById("content");

--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -59,6 +59,7 @@ export function attachEventListeners() {
 
   // メモ一覧のクリック（選択/削除）
   noteListEl.addEventListener("click", handleNoteListClick);
+  noteListEl.addEventListener("keydown", handleNoteListKeydown);
   noteListEl.addEventListener("dragstart", handleDragStart);
   noteListEl.addEventListener("dragend", handleDragEnd);
   noteListEl.addEventListener("dragover", handleDragOver);
@@ -130,7 +131,26 @@ function handleNoteListClick(event) {
 
   const item = event.target.closest("li[data-id]");
   if (!item) return;
-  const noteId = item.dataset.id;
+  selectNoteId(item.dataset.id);
+}
+
+function handleNoteListKeydown(event) {
+  // Enter/Spaceでメモ選択（アクセシビリティ/キーボード操作）
+  const key = event.key;
+  if (key !== "Enter" && key !== " ") return;
+
+  // 削除ボタンなどネイティブ操作がある要素は、既定動作に任せる
+  if (event.target.closest?.(".note-list__delete")) return;
+
+  const item = event.target.closest?.("li[data-id]");
+  if (!item) return;
+
+  event.preventDefault();
+  selectNoteId(item.dataset.id);
+}
+
+function selectNoteId(noteId) {
+  if (!noteId) return;
   if (noteId === getActiveNoteId()) return;
   setActiveNoteId(noteId);
   // 選択変更も即座に保存しておくことで、タブを開いた際に同じメモを表示できる

--- a/extension/src/render.js
+++ b/extension/src/render.js
@@ -182,6 +182,9 @@ function createNoteListItem(note, isActive) {
 
   if (isActive) {
     item.classList.add("note-list__item--active");
+    item.setAttribute("aria-current", "true");
+  } else {
+    item.removeAttribute("aria-current");
   }
 
   const title = document.createElement("p");


### PR DESCRIPTION
Fixes #9
Fixes #10

## 変更内容
- メモ一覧で Enter/Space でもメモを選択できるように（削除ボタンは既定動作）
- アクティブ項目に aria-current="true" を付与
- docs の「閉じる」で window.close() が効かない場合、戻る/案内表示にフォールバック
