### PR TITLE
fix: remove options_page from manifest (not implemented yet)

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,6 +12,5 @@
   },
   "action": {
     "default_popup": "src/popup.html"
-  },
-  "options_page": "src/options.html"
+  }
 }


### PR DESCRIPTION
## Summary
- UX-001対応: 未実装のoptions_pageをmanifest.jsonから削除
- options.htmlは「Coming soon」表示のみだったため、設定リンクを非表示に
- options.htmlファイル自体は将来の実装用に残存

## Reason
設定ページが機能しない状態でリンクが表示されることは
ユーザーの期待を裏切るUX問題となるため削除。

## Test plan
- [ ] 拡張機能の設定リンクが非表示になること
- [ ] 拡張機能が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)