### PR TITLE
fix: add content_security_policy to manifest.json

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -4,6 +4,9 @@
   "version": "0.1.0",
   "description": "MarkdownメモとMermaidプレビューをローカルで扱えるChrome拡張です。",
   "permissions": ["storage"],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self'"
+  },
   "icons": {
     "16": "icons/icon16.png",
     "32": "icons/icon32.png",


### PR DESCRIPTION
## Summary
- CODE-003対応: manifest.jsonにContent Security Policyを追加
- script-src 'self': 拡張機能自身のスクリプトのみ実行許可
- object-src 'self': プラグインコンテンツを拡張機能自身に制限

## Test plan
- [ ] 拡張機能が正常に読み込まれること
- [ ] Mermaid図が正常に描画されること
- [ ] コンソールにCSP違反エラーがないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)