### PR TITLE
perf: optimize render with DocumentFragment and mermaid init

### DIFF
--- a/extension/src/preview_renderer.js
+++ b/extension/src/preview_renderer.js
@@ -1,5 +1,20 @@
 import { renderMarkdown } from "./markdown.js";
 
+// Mermaid初期化フラグ（1回のみ初期化）
+let mermaidInitialized = false;
+
+function initMermaidIfNeeded() {
+  if (mermaidInitialized || typeof mermaid === "undefined") return;
+  // Mermaid はユーザー入力を描画するため、strict設定で安全側に倒す
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: "dark",
+    securityLevel: "strict",
+    flowchart: { htmlLabels: false },
+  });
+  mermaidInitialized = true;
+}
+
 export function renderPreview({ text, target }) {
   if (!target) return;
   // プレビュー領域を初期化（毎回描画し直す）
@@ -70,13 +85,7 @@ export function renderPreview({ text, target }) {
 
   if (hasMermaid && typeof mermaid !== "undefined") {
     try {
-      // Mermaid はユーザー入力を描画するため、strict設定で安全側に倒す
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: "dark",
-        securityLevel: "strict",
-        flowchart: { htmlLabels: false },
-      });
+      initMermaidIfNeeded();
       mermaid.run({ querySelector: ".preview-markdown .mermaid" });
     } catch (e) {
       console.error("Mermaid render error", e);

--- a/extension/src/preview_renderer.js
+++ b/extension/src/preview_renderer.js
@@ -15,6 +15,43 @@ function initMermaidIfNeeded() {
   mermaidInitialized = true;
 }
 
+/**
+ * テーマ変更時にMermaidを再初期化する
+ * @param {string} theme - 適用するテーマ名 ('dark', 'default', 'forest', 'neutral', etc.)
+ */
+export function reinitializeMermaidWithTheme(theme = "dark") {
+  if (typeof mermaid === "undefined") return;
+
+  // 初期化されていなければ先に初期化
+  if (!mermaidInitialized) {
+    initMermaidIfNeeded();
+  }
+
+  // テーマ設定を更新
+  mermaid.initialize({
+    startOnLoad: false,
+    theme: theme,
+    securityLevel: "strict",
+    flowchart: { htmlLabels: false },
+  });
+
+  // 既存のダイアグラムを再レンダリング
+  const mermaidElements = document.querySelectorAll(".preview-markdown .mermaid");
+  mermaidElements.forEach((el) => {
+    // data-processed を削除して再処理可能にする
+    el.removeAttribute("data-processed");
+  });
+
+  // 再レンダリング実行
+  if (mermaidElements.length > 0) {
+    try {
+      mermaid.run({ querySelector: ".preview-markdown .mermaid" });
+    } catch (e) {
+      console.error("Mermaid re-render error", e);
+    }
+  }
+}
+
 export function renderPreview({ text, target }) {
   if (!target) return;
   // プレビュー領域を初期化（毎回描画し直す）

--- a/extension/src/render.js
+++ b/extension/src/render.js
@@ -27,12 +27,15 @@ export function renderNoteList({ notes, sortOrder, sortDirection = "desc", activ
       ? sortOrder
       : notes.map((note) => note.id);
 
+  // DocumentFragmentを使用して一括追加（リフロー最適化）
+  const fragment = document.createDocumentFragment();
   for (const noteId of orderToUse) {
     const note = noteMap.get(noteId);
     if (!note) continue;
     const item = createNoteListItem(note, note.id === activeNoteId);
-    noteListEl.appendChild(item);
+    fragment.appendChild(item);
   }
+  noteListEl.appendChild(fragment);
 }
 
 export function updateEditor(note, notesCount = 0) {


### PR DESCRIPTION
## Summary
- PERF-001対応: render.jsでDocumentFragmentを使用して一括DOM追加
- PERF-003対応: preview_renderer.jsでmermaid.initialize()を初回のみ実行

## Changes
### render.js
- renderNoteList()でDocumentFragmentを使用
- リフロー回数を削減し、メモリスト描画を高速化

### preview_renderer.js
- mermaidInitializedフラグを追加
- initMermaidIfNeeded()関数でlazy initialization
- プレビュー更新時の不要な初期化を排除

## Test plan
- [ ] メモ一覧の表示が正常に動作すること
- [ ] メモの追加・削除・並び替えが動作すること
- [ ] Mermaid図のプレビューが正常に動作すること
- [ ] テーマ切替後もMermaidが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)