### PR TITLE
fix: add chrome.runtime.lastError check in storage.js

### DIFF
--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -134,7 +134,9 @@ function handleNoteListClick(event) {
   if (noteId === getActiveNoteId()) return;
   setActiveNoteId(noteId);
   // 選択変更も即座に保存しておくことで、タブを開いた際に同じメモを表示できる
-  persistState();
+  persistState().catch((error) => {
+    console.error("Failed to persist state on note selection:", error);
+  });
   renderApp();
 }
 
@@ -681,8 +683,13 @@ function scheduleAutoSave() {
   setStatus("saving", "自動保存中…");
   autoSaveTimeout = setTimeout(async () => {
     autoSaveTimeout = null;
-    await persistState();
-    setStatus("saved", "保存しました");
+    try {
+      await persistState();
+      setStatus("saved", "保存しました");
+    } catch (error) {
+      console.error("Failed to auto-save:", error);
+      setStatus("idle", "保存に失敗しました");
+    }
     if (statusResetTimeout) {
       clearTimeout(statusResetTimeout);
     }

--- a/extension/src/storage.js
+++ b/extension/src/storage.js
@@ -4,8 +4,14 @@ const SORT_DIRECTION_KEY = "sortDirection";
 const ACTIVE_NOTE_KEY = "activeNoteId";
 
 function withStorage(action) {
-  return new Promise((resolve) => {
-    action(resolve);
+  return new Promise((resolve, reject) => {
+    action((result) => {
+      if (chrome.runtime.lastError) {
+        reject(new Error(chrome.runtime.lastError.message));
+      } else {
+        resolve(result);
+      }
+    });
   });
 }
 


### PR DESCRIPTION
## Summary
- BUG-001対応: chrome.storage API呼び出し時のエラーハンドリングを追加
- withStorage関数でchrome.runtime.lastErrorをチェック
- エラー発生時はPromiseをrejectするように修正

## Test plan
- [ ] 正常なストレージ操作が動作すること
- [ ] ストレージエラー時にエラーがキャッチされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)