### PR TITLE
feat: add color theme switching with 5 themes

### DIFF
--- a/extension/src/popup.css
+++ b/extension/src/popup.css
@@ -1,66 +1,13 @@
-:root {
-  color-scheme: light dark;
-  --color-bg: #f7f7f7;
-  --color-bg-dark: #1e1e1e;
-  --color-sidebar: #ffffff;
-  --color-sidebar-dark: #161b22;
-  --color-border: rgba(15, 23, 42, 0.08);
-  --color-border-dark: rgba(148, 163, 184, 0.24);
-  --color-primary: #2563eb;
-  --color-primary-soft: rgba(37, 99, 235, 0.12);
-  --color-danger: #ef4444;
-  --color-text: #0f172a;
-  --color-text-muted: #64748b;
-  --color-text-dark: #e2e8f0;
-  --shadow: 0 24px 50px rgba(15, 23, 42, 0.16);
-}
+/* CSS変数は themes.css で定義 */
 
-.editor[data-theme="dark"] .pill-button {
-  background: rgba(59, 130, 246, 0.24);
-  color: var(--color-text-dark);
-}
-
-.editor[data-theme="dark"] .pill-button:hover {
-  background: rgba(59, 130, 246, 0.32);
-}
-
-.editor[data-theme="dark"] .icon-button {
-  color: rgba(226, 232, 240, 0.85);
-}
-
-.editor[data-theme="dark"] .icon-button:hover {
-  background: rgba(96, 165, 250, 0.14);
-  color: #f87171;
-}
-
-.editor[data-theme="dark"] .editor__title-input {
-  background: rgba(15, 23, 42, 0.65);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: var(--color-text-dark);
-}
-
-.editor[data-theme="dark"] .editor__textarea {
-  background: rgba(15, 23, 42, 0.6);
-  color: var(--color-text-dark);
-}
-
-.editor[data-theme="dark"] .editor__meta,
-.editor[data-theme="dark"] .editor__status,
-.editor[data-theme="dark"] .note-list__meta {
-  color: rgba(148, 163, 184, 0.8);
-}
-
-.editor[data-theme="dark"] .preview {
-  background: rgba(15, 23, 42, 0.78);
-  color: var(--color-text-dark);
-}
+/* テーマ別スタイルはthemes.cssのCSS変数で管理 */
 
 body {
   margin: 0;
   font-family: "Noto Sans JP", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     sans-serif;
-  background: var(--color-bg);
-  color: var(--color-text);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
   min-width: 720px;
   min-height: 480px;
 }
@@ -69,60 +16,44 @@ body {
   box-sizing: border-box;
 }
 
-@media (prefers-color-scheme: dark) {
-  body {
-    background: var(--color-bg-dark);
-  }
-}
+/* テーマはthemes.cssのCSS変数で管理 */
 
 .app {
   display: grid;
   grid-template-columns: 320px 1fr;
   height: 100vh;
-  background: var(--color-bg);
+  background: var(--bg-secondary);
 }
 
 .sidebar {
-  background: var(--color-sidebar);
-  border-right: 1px solid var(--color-border);
+  background: var(--bg-sidebar);
+  border-right: 1px solid var(--border-color);
   display: flex;
   flex-direction: column;
   padding: 20px;
   gap: 16px;
 }
 
-@media (prefers-color-scheme: dark) {
-  .sidebar {
-    background: var(--color-sidebar-dark);
-    border-color: var(--color-border-dark);
-  }
+.sidebar__subtitle {
+  color: var(--text-muted);
 }
 
-.sidebar[data-theme="dark"] {
-  background: #0b1120;
-  border-color: var(--color-border-dark);
+.badge {
+  background: var(--accent-soft);
+  color: var(--text-primary);
 }
 
-.sidebar[data-theme="dark"] .sidebar__subtitle {
-  color: rgba(148, 163, 184, 0.75);
+.note-list__item {
+  border-color: var(--border-color-light);
 }
 
-.sidebar[data-theme="dark"] .badge {
-  background: rgba(59, 130, 246, 0.26);
-  color: var(--color-text-dark);
+.note-list__item:hover,
+.note-list__item--active {
+  background: var(--bg-hover);
 }
 
-.sidebar[data-theme="dark"] .note-list__item {
-  border-color: rgba(148, 163, 184, 0.14);
-}
-
-.sidebar[data-theme="dark"] .note-list__item:hover,
-.sidebar[data-theme="dark"] .note-list__item--active {
-  background: rgba(96, 165, 250, 0.18);
-}
-
-.sidebar[data-theme="dark"] .note-list__title {
-  color: var(--color-text-dark);
+.note-list__title {
+  color: var(--text-primary);
 }
 
 .sidebar__header {
@@ -215,7 +146,7 @@ body {
   font-size: 15px;
   font-weight: 600;
   margin: 0;
-  color: var(--color-text);
+  color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -224,7 +155,7 @@ body {
 
 .note-list__meta {
   font-size: 12px;
-  color: var(--color-text-muted);
+  color: var(--text-secondary);
 }
 
 .note-list__footer {
@@ -260,7 +191,7 @@ body {
   height: 100%;
   padding: 28px 32px;
   gap: 18px;
-  background: var(--color-sidebar);
+  background: var(--bg-primary);
 }
 
 .editor__content {
@@ -281,18 +212,12 @@ body {
 
 .empty-state__card {
   width: min(560px, 100%);
-  border: 1px solid rgba(148, 163, 184, 0.22);
+  border: 1px solid var(--border-color);
   border-radius: 18px;
   padding: 22px 22px 20px;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.08), rgba(148, 163, 184, 0.06));
-  box-shadow: 0 18px 50px rgba(15, 23, 42, 0.08);
+  background: var(--bg-tertiary);
+  box-shadow: var(--shadow-soft);
   text-align: center;
-}
-
-.editor[data-theme="dark"] .empty-state__card {
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12), rgba(148, 163, 184, 0.08));
-  border-color: rgba(148, 163, 184, 0.22);
-  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.28);
 }
 
 .empty-state__icon {
@@ -302,13 +227,8 @@ body {
   margin: 0 auto 12px;
   display: grid;
   place-items: center;
-  background: rgba(37, 99, 235, 0.12);
-  color: rgba(37, 99, 235, 0.95);
-}
-
-.editor[data-theme="dark"] .empty-state__icon {
-  background: rgba(59, 130, 246, 0.22);
-  color: rgba(226, 232, 240, 0.92);
+  background: var(--accent-soft);
+  color: var(--accent-color);
 }
 
 .empty-state__title {
@@ -316,17 +236,14 @@ body {
   font-size: 18px;
   font-weight: 800;
   letter-spacing: 0.01em;
+  color: var(--text-primary);
 }
 
 .empty-state__text {
   margin: 10px 0 0;
   font-size: 13px;
-  color: var(--color-text-muted);
+  color: var(--text-secondary);
   line-height: 1.6;
-}
-
-.editor[data-theme="dark"] .empty-state__text {
-  color: rgba(148, 163, 184, 0.82);
 }
 
 .empty-state__actions {
@@ -338,9 +255,9 @@ body {
 }
 
 .empty-state__secondary {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(255, 255, 255, 0.8);
-  color: rgba(15, 23, 42, 0.88);
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-primary);
   border-radius: 999px;
   padding: 10px 16px;
   font-size: 13px;
@@ -350,30 +267,15 @@ body {
 }
 
 .empty-state__secondary:hover {
-  background: rgba(255, 255, 255, 0.95);
-  border-color: rgba(148, 163, 184, 0.45);
+  background: var(--bg-hover);
+  border-color: var(--border-color-input);
 }
 
 .empty-state__secondary:active {
   transform: translateY(1px);
 }
 
-.editor[data-theme="dark"] .empty-state__secondary {
-  background: rgba(255, 255, 255, 0.04);
-  color: rgba(226, 232, 240, 0.92);
-  border-color: rgba(148, 163, 184, 0.26);
-}
-
-.editor[data-theme="dark"] .empty-state__secondary:hover {
-  background: rgba(148, 163, 184, 0.12);
-  border-color: rgba(148, 163, 184, 0.5);
-}
-
-@media (prefers-color-scheme: dark) {
-  .editor {
-    background: #111827;
-  }
-}
+/* テーマはthemes.cssのCSS変数で管理 */
 
 .editor__header {
   display: flex;
@@ -396,22 +298,23 @@ body {
   width: 100%;
   font-size: 22px;
   padding: 12px 16px;
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid var(--border-color-input);
   border-radius: 12px;
-  background: rgba(255, 255, 255, 0.85);
+  background: var(--bg-input);
+  color: var(--text-primary);
   box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.04);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .editor__title-input:focus {
   outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .editor__meta {
   font-size: 12px;
-  color: var(--color-text-muted);
+  color: var(--text-secondary);
 }
 
 .editor__actions {
@@ -445,7 +348,7 @@ body {
 .editor__textarea {
   width: 100%;
   flex: 1;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--border-color-input);
   border-radius: 16px;
   padding: 18px;
   resize: none;
@@ -454,30 +357,25 @@ body {
   line-height: 1.5;
   tab-size: 4;
   -moz-tab-size: 4;
-  background: rgba(248, 250, 252, 0.9);
+  background: var(--bg-textarea);
+  color: var(--text-primary);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .editor__textarea:focus {
   outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.14);
+  border-color: var(--accent-color);
+  box-shadow: 0 0 0 3px var(--accent-soft);
 }
 
 .preview {
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--border-color-input);
   border-radius: 16px;
   padding: 18px 20px;
   overflow-y: auto;
-  background: #ffffff;
+  background: var(--bg-preview);
+  color: var(--text-primary);
   box-shadow: inset 0 1px 1px rgba(15, 23, 42, 0.05);
-}
-
-@media (prefers-color-scheme: dark) {
-  .preview {
-    background: rgba(15, 23, 42, 0.85);
-    border-color: var(--color-border-dark);
-  }
 }
 
 .preview h1,
@@ -533,12 +431,12 @@ body {
 }
 
 .button--primary {
-  background: var(--color-primary);
+  background: var(--accent-color);
   color: #ffffff;
 }
 
 .button--danger {
-  background: var(--color-danger);
+  background: var(--danger-color);
   color: #ffffff;
 }
 
@@ -548,23 +446,14 @@ body {
   padding: 10px 20px;
   font-size: 13px;
   font-weight: 600;
-  background: rgba(37, 99, 235, 0.12);
-  color: var(--color-primary);
+  background: var(--bg-button);
+  color: var(--accent-color);
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease, transform 0.1s ease;
 }
 
-.editor[data-theme="dark"] .pill-button {
-  background: rgba(59, 130, 246, 0.24);
-  color: var(--color-text-dark);
-}
-
-.editor[data-theme="dark"] .pill-button:hover {
-  background: rgba(59, 130, 246, 0.32);
-}
-
 .pill-button:hover {
-  background: rgba(37, 99, 235, 0.22);
+  background: var(--bg-button-hover);
 }
 
 .pill-button:active {
@@ -595,8 +484,8 @@ body {
 }
 
 .icon-button--primary {
-  background: rgba(37, 99, 235, 0.14);
-  color: var(--color-primary);
+  background: var(--accent-soft);
+  color: var(--accent-color);
   padding: 8px;
   border-radius: 50%;
   width: 42px;
@@ -615,7 +504,7 @@ body {
   align-items: center;
   gap: 8px;
   font-size: 12px;
-  color: var(--color-text-muted);
+  color: var(--text-secondary);
 }
 
 .status-indicator {

--- a/extension/src/popup.html
+++ b/extension/src/popup.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Mermaid Markdown Memo</title>
+    <link rel="stylesheet" href="themes.css" />
     <link rel="stylesheet" href="popup.css" />
   </head>
   <body>
@@ -14,6 +15,7 @@
           </div>
           <div class="sidebar__header-actions">
             <span id="noteCount" class="badge" aria-live="polite">0</span>
+            <div id="themeSelector"></div>
             <button id="openDocs" class="docs-button" type="button" aria-label="仕様書を開く">仕様書</button>
             <button
               id="sortToggle"

--- a/extension/src/popup.js
+++ b/extension/src/popup.js
@@ -1,5 +1,5 @@
 import { ensureElementsExist } from "./dom.js";
-import { initializeTheme } from "./theme.js";
+import { initializeTheme, createThemeSelectorUI } from "./theme.js";
 import { initializeState } from "./state.js";
 import { attachEventListeners, renderApp } from "./events.js";
 import { setStatus } from "./render.js";
@@ -12,7 +12,14 @@ async function init() {
     return;
   }
 
-  initializeTheme();
+  await initializeTheme();
+
+  // テーマセレクターUIを追加
+  const themeSelectorContainer = document.getElementById("themeSelector");
+  if (themeSelectorContainer) {
+    themeSelectorContainer.appendChild(createThemeSelectorUI());
+  }
+
   attachEventListeners();
 
   try {

--- a/extension/src/preview.html
+++ b/extension/src/preview.html
@@ -4,18 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>プレビュー | Mermaid Markdown Memo</title>
+    <link rel="stylesheet" href="themes.css" />
     <link rel="stylesheet" href="popup.css" />
     <link rel="stylesheet" href="preview.css" />
   </head>
   <body>
-    <div class="app" data-theme="dark">
-      <aside class="sidebar" data-theme="dark">
+    <div class="app">
+      <aside class="sidebar">
         <header class="sidebar__header">
           <div class="sidebar__title-group">
             <h1 class="sidebar__title">メモ</h1>
           </div>
           <div class="sidebar__header-actions">
             <span id="noteCount" class="badge" aria-live="polite">0</span>
+            <div id="themeSelector"></div>
             <button id="openDocs" class="docs-button" type="button" aria-label="仕様書を開く">仕様書</button>
             <button
               id="sortToggle"

--- a/extension/src/preview.js
+++ b/extension/src/preview.js
@@ -1,5 +1,5 @@
 import { ensureElementsExist, elements } from "./dom.js";
-import { initializeTheme } from "./theme.js";
+import { initializeTheme, createThemeSelectorUI } from "./theme.js";
 import { initializeState, getActiveNote } from "./state.js";
 import { attachEventListeners, renderApp } from "./events.js";
 import { setStatus } from "./render.js";
@@ -17,8 +17,15 @@ async function init() {
     return;
   }
 
-  // テーマ（ダーク/ライト）を反映
-  initializeTheme();
+  // テーマを初期化（ストレージから読み込み）
+  await initializeTheme();
+
+  // テーマセレクターUIを追加
+  const themeSelectorContainer = document.getElementById("themeSelector");
+  if (themeSelectorContainer) {
+    themeSelectorContainer.appendChild(createThemeSelectorUI());
+  }
+
   // 既存のイベント一式（作成/削除/並び替え/編集）を使い回す
   attachEventListeners();
 

--- a/extension/src/theme.js
+++ b/extension/src/theme.js
@@ -1,22 +1,191 @@
-import { applyTheme } from "./render.js";
+// =================================================================
+// Mermaid Markdown Memo - Theme Management
+// =================================================================
 
-export function initializeTheme() {
-  const prefersDark =
-    typeof window !== "undefined" && typeof window.matchMedia === "function"
-      ? window.matchMedia("(prefers-color-scheme: dark)")
-      : null;
+const THEMES = ['light', 'dark', 'solarized-light', 'nord', 'dracula'];
+const THEME_LABELS = {
+  'light': 'Light',
+  'dark': 'Dark',
+  'solarized-light': 'Solarized Light',
+  'nord': 'Nord',
+  'dracula': 'Dracula'
+};
+const DEFAULT_THEME = 'light';
+const STORAGE_KEY = 'selectedTheme';
 
-  applyTheme(prefersDark ? prefersDark.matches : false);
+let currentTheme = DEFAULT_THEME;
 
-  if (!prefersDark) {
-    return;
+/**
+ * Load theme from storage and apply it
+ * @returns {Promise<string>} The loaded theme name
+ */
+export async function loadTheme() {
+  try {
+    const result = await chrome.storage.local.get(STORAGE_KEY);
+    const theme = result[STORAGE_KEY];
+    if (theme && THEMES.includes(theme)) {
+      currentTheme = theme;
+    } else {
+      currentTheme = DEFAULT_THEME;
+    }
+  } catch (error) {
+    console.warn('Failed to load theme from storage:', error);
+    currentTheme = DEFAULT_THEME;
   }
+  applyTheme(currentTheme);
+  return currentTheme;
+}
 
-  const handleThemeChange = (event) => applyTheme(event.matches);
-
-  if (typeof prefersDark.addEventListener === "function") {
-    prefersDark.addEventListener("change", handleThemeChange);
-  } else if (typeof prefersDark.addListener === "function") {
-    prefersDark.addListener(handleThemeChange);
+/**
+ * Apply theme to document
+ * @param {string} theme - Theme name to apply
+ */
+export function applyTheme(theme) {
+  if (!THEMES.includes(theme)) {
+    theme = DEFAULT_THEME;
   }
+  document.documentElement.setAttribute('data-theme', theme);
+  currentTheme = theme;
+}
+
+/**
+ * Set and save theme
+ * @param {string} theme - Theme name to set
+ * @returns {Promise<void>}
+ */
+export async function setTheme(theme) {
+  if (!THEMES.includes(theme)) {
+    theme = DEFAULT_THEME;
+  }
+  applyTheme(theme);
+  try {
+    await chrome.storage.local.set({ [STORAGE_KEY]: theme });
+  } catch (error) {
+    console.error('Failed to save theme to storage:', error);
+  }
+}
+
+/**
+ * Get current theme
+ * @returns {string} Current theme name
+ */
+export function getCurrentTheme() {
+  return currentTheme;
+}
+
+/**
+ * Get all available themes
+ * @returns {Array<{id: string, label: string}>}
+ */
+export function getThemes() {
+  return THEMES.map(id => ({ id, label: THEME_LABELS[id] }));
+}
+
+/**
+ * Cycle to next theme
+ * @returns {Promise<string>} The new theme name
+ */
+export async function cycleTheme() {
+  const currentIndex = THEMES.indexOf(currentTheme);
+  const nextIndex = (currentIndex + 1) % THEMES.length;
+  const nextTheme = THEMES[nextIndex];
+  await setTheme(nextTheme);
+  return nextTheme;
+}
+
+/**
+ * Initialize theme - for backward compatibility
+ * This replaces the old initializeTheme that used prefers-color-scheme
+ */
+export async function initializeTheme() {
+  await loadTheme();
+}
+
+/**
+ * Create theme selector UI element
+ * @returns {HTMLElement} Theme selector container element
+ */
+export function createThemeSelectorUI() {
+  const container = document.createElement('div');
+  container.className = 'theme-selector';
+
+  const button = document.createElement('button');
+  button.className = 'theme-selector__button';
+  button.type = 'button';
+  button.setAttribute('aria-haspopup', 'listbox');
+  button.setAttribute('aria-expanded', 'false');
+  button.innerHTML = `
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+    <span class="theme-selector__label">${THEME_LABELS[currentTheme]}</span>
+  `;
+
+  const dropdown = document.createElement('div');
+  dropdown.className = 'theme-selector__dropdown';
+  dropdown.setAttribute('role', 'listbox');
+  dropdown.setAttribute('data-open', 'false');
+
+  THEMES.forEach(themeId => {
+    const option = document.createElement('button');
+    option.className = 'theme-selector__option';
+    option.type = 'button';
+    option.setAttribute('role', 'option');
+    option.setAttribute('aria-selected', themeId === currentTheme ? 'true' : 'false');
+    option.dataset.theme = themeId;
+    option.innerHTML = `
+      <span class="theme-selector__swatch theme-selector__swatch--${themeId}"></span>
+      <span>${THEME_LABELS[themeId]}</span>
+    `;
+    option.addEventListener('click', async () => {
+      await setTheme(themeId);
+      updateSelectorUI(container);
+      closeDropdown(container);
+    });
+    dropdown.appendChild(option);
+  });
+
+  button.addEventListener('click', () => {
+    const isOpen = dropdown.getAttribute('data-open') === 'true';
+    dropdown.setAttribute('data-open', isOpen ? 'false' : 'true');
+    button.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+  });
+
+  // Close dropdown when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!container.contains(e.target)) {
+      closeDropdown(container);
+    }
+  });
+
+  container.appendChild(button);
+  container.appendChild(dropdown);
+
+  return container;
+}
+
+function updateSelectorUI(container) {
+  const label = container.querySelector('.theme-selector__label');
+  if (label) {
+    label.textContent = THEME_LABELS[currentTheme];
+  }
+  const options = container.querySelectorAll('.theme-selector__option');
+  options.forEach(option => {
+    option.setAttribute('aria-selected', option.dataset.theme === currentTheme ? 'true' : 'false');
+  });
+}
+
+function closeDropdown(container) {
+  const dropdown = container.querySelector('.theme-selector__dropdown');
+  const button = container.querySelector('.theme-selector__button');
+  if (dropdown) dropdown.setAttribute('data-open', 'false');
+  if (button) button.setAttribute('aria-expanded', 'false');
 }

--- a/extension/src/themes.css
+++ b/extension/src/themes.css
@@ -1,0 +1,254 @@
+/* =================================================================
+   Mermaid Markdown Memo - Color Theme Definitions
+   ================================================================= */
+
+:root {
+  /* Light Theme (default) */
+  --bg-primary: #ffffff;
+  --bg-secondary: #f7f7f7;
+  --bg-tertiary: #f0f0f0;
+  --bg-sidebar: #ffffff;
+  --bg-sidebar-header: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0.54));
+  --bg-input: rgba(255, 255, 255, 0.85);
+  --bg-textarea: rgba(248, 250, 252, 0.9);
+  --bg-hover: rgba(37, 99, 235, 0.18);
+  --bg-button: rgba(37, 99, 235, 0.12);
+  --bg-button-hover: rgba(37, 99, 235, 0.22);
+  --bg-code: #0f172a;
+  --bg-preview: #ffffff;
+  --text-primary: #0f172a;
+  --text-secondary: #64748b;
+  --text-muted: rgba(100, 116, 139, 0.9);
+  --text-inverse: #e2e8f0;
+  --border-color: rgba(15, 23, 42, 0.08);
+  --border-color-light: rgba(148, 163, 184, 0.18);
+  --border-color-input: rgba(148, 163, 184, 0.4);
+  --accent-color: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --accent-hover: #1d4ed8;
+  --danger-color: #ef4444;
+  --success-color: #22c55e;
+  --shadow: 0 24px 50px rgba(15, 23, 42, 0.16);
+  --shadow-soft: 0 10px 28px rgba(15, 23, 42, 0.08);
+}
+
+[data-theme="dark"] {
+  /* Dark Theme */
+  --bg-primary: #1e1e1e;
+  --bg-secondary: #111827;
+  --bg-tertiary: #2d2d2d;
+  --bg-sidebar: #0b1120;
+  --bg-sidebar-header: linear-gradient(135deg, rgba(15, 23, 42, 0.72), rgba(15, 23, 42, 0.54));
+  --bg-input: rgba(15, 23, 42, 0.65);
+  --bg-textarea: rgba(15, 23, 42, 0.6);
+  --bg-hover: rgba(96, 165, 250, 0.18);
+  --bg-button: rgba(59, 130, 246, 0.24);
+  --bg-button-hover: rgba(59, 130, 246, 0.32);
+  --bg-code: rgba(15, 23, 42, 0.7);
+  --bg-preview: rgba(15, 23, 42, 0.78);
+  --text-primary: #e0e0e0;
+  --text-secondary: #a0a0a0;
+  --text-muted: rgba(148, 163, 184, 0.8);
+  --text-inverse: #0f172a;
+  --border-color: rgba(148, 163, 184, 0.24);
+  --border-color-light: rgba(148, 163, 184, 0.14);
+  --border-color-input: rgba(148, 163, 184, 0.35);
+  --accent-color: #4da6ff;
+  --accent-soft: rgba(59, 130, 246, 0.26);
+  --accent-hover: #80bdff;
+  --danger-color: #f87171;
+  --success-color: #4ade80;
+  --shadow: 0 24px 50px rgba(0, 0, 0, 0.35);
+  --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.22);
+}
+
+[data-theme="solarized-light"] {
+  /* Solarized Light Theme */
+  --bg-primary: #fdf6e3;
+  --bg-secondary: #eee8d5;
+  --bg-tertiary: #e4ddc8;
+  --bg-sidebar: #fdf6e3;
+  --bg-sidebar-header: linear-gradient(135deg, rgba(101, 123, 131, 0.85), rgba(88, 110, 117, 0.7));
+  --bg-input: rgba(253, 246, 227, 0.9);
+  --bg-textarea: rgba(238, 232, 213, 0.8);
+  --bg-hover: rgba(38, 139, 210, 0.15);
+  --bg-button: rgba(38, 139, 210, 0.12);
+  --bg-button-hover: rgba(38, 139, 210, 0.22);
+  --bg-code: #002b36;
+  --bg-preview: #fdf6e3;
+  --text-primary: #657b83;
+  --text-secondary: #839496;
+  --text-muted: rgba(131, 148, 150, 0.9);
+  --text-inverse: #fdf6e3;
+  --border-color: rgba(101, 123, 131, 0.2);
+  --border-color-light: rgba(101, 123, 131, 0.12);
+  --border-color-input: rgba(101, 123, 131, 0.35);
+  --accent-color: #268bd2;
+  --accent-soft: rgba(38, 139, 210, 0.15);
+  --accent-hover: #2aa198;
+  --danger-color: #dc322f;
+  --success-color: #859900;
+  --shadow: 0 24px 50px rgba(101, 123, 131, 0.15);
+  --shadow-soft: 0 10px 28px rgba(101, 123, 131, 0.1);
+}
+
+[data-theme="nord"] {
+  /* Nord Theme */
+  --bg-primary: #2e3440;
+  --bg-secondary: #3b4252;
+  --bg-tertiary: #434c5e;
+  --bg-sidebar: #2e3440;
+  --bg-sidebar-header: linear-gradient(135deg, rgba(46, 52, 64, 0.95), rgba(59, 66, 82, 0.85));
+  --bg-input: rgba(59, 66, 82, 0.8);
+  --bg-textarea: rgba(67, 76, 94, 0.7);
+  --bg-hover: rgba(136, 192, 208, 0.2);
+  --bg-button: rgba(136, 192, 208, 0.15);
+  --bg-button-hover: rgba(136, 192, 208, 0.25);
+  --bg-code: #242933;
+  --bg-preview: rgba(46, 52, 64, 0.9);
+  --text-primary: #eceff4;
+  --text-secondary: #d8dee9;
+  --text-muted: rgba(216, 222, 233, 0.7);
+  --text-inverse: #2e3440;
+  --border-color: rgba(216, 222, 233, 0.15);
+  --border-color-light: rgba(216, 222, 233, 0.1);
+  --border-color-input: rgba(216, 222, 233, 0.25);
+  --accent-color: #88c0d0;
+  --accent-soft: rgba(136, 192, 208, 0.2);
+  --accent-hover: #81a1c1;
+  --danger-color: #bf616a;
+  --success-color: #a3be8c;
+  --shadow: 0 24px 50px rgba(0, 0, 0, 0.4);
+  --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dracula"] {
+  /* Dracula Theme */
+  --bg-primary: #282a36;
+  --bg-secondary: #44475a;
+  --bg-tertiary: #6272a4;
+  --bg-sidebar: #21222c;
+  --bg-sidebar-header: linear-gradient(135deg, rgba(68, 71, 90, 0.9), rgba(40, 42, 54, 0.85));
+  --bg-input: rgba(68, 71, 90, 0.7);
+  --bg-textarea: rgba(68, 71, 90, 0.6);
+  --bg-hover: rgba(189, 147, 249, 0.2);
+  --bg-button: rgba(189, 147, 249, 0.18);
+  --bg-button-hover: rgba(189, 147, 249, 0.28);
+  --bg-code: #1e1f29;
+  --bg-preview: rgba(40, 42, 54, 0.95);
+  --text-primary: #f8f8f2;
+  --text-secondary: #6272a4;
+  --text-muted: rgba(98, 114, 164, 0.9);
+  --text-inverse: #282a36;
+  --border-color: rgba(98, 114, 164, 0.3);
+  --border-color-light: rgba(98, 114, 164, 0.2);
+  --border-color-input: rgba(98, 114, 164, 0.4);
+  --accent-color: #bd93f9;
+  --accent-soft: rgba(189, 147, 249, 0.2);
+  --accent-hover: #ff79c6;
+  --danger-color: #ff5555;
+  --success-color: #50fa7b;
+  --shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
+  --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+/* Theme Selector Styles */
+.theme-selector {
+  position: relative;
+}
+
+.theme-selector__button {
+  border: 1px solid rgba(148, 163, 184, 0.26);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-inverse, rgba(226, 232, 240, 0.92));
+  border-radius: 999px;
+  padding: 7px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.theme-selector__button:hover {
+  background: rgba(148, 163, 184, 0.14);
+  border-color: rgba(148, 163, 184, 0.5);
+}
+
+.theme-selector__dropdown {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  min-width: 160px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: 12px;
+  box-shadow: var(--shadow-soft);
+  padding: 6px;
+  z-index: 100;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-8px);
+  transition: opacity 0.2s ease, visibility 0.2s ease, transform 0.2s ease;
+}
+
+.theme-selector__dropdown[data-open="true"] {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.theme-selector__option {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: background 0.15s ease;
+}
+
+.theme-selector__option:hover {
+  background: var(--bg-hover);
+}
+
+.theme-selector__option[aria-selected="true"] {
+  background: var(--accent-soft);
+  font-weight: 600;
+}
+
+.theme-selector__swatch {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.theme-selector__swatch--light {
+  background: linear-gradient(135deg, #ffffff 50%, #f5f5f5 50%);
+}
+
+.theme-selector__swatch--dark {
+  background: linear-gradient(135deg, #1e1e1e 50%, #2d2d2d 50%);
+}
+
+.theme-selector__swatch--solarized-light {
+  background: linear-gradient(135deg, #fdf6e3 50%, #eee8d5 50%);
+}
+
+.theme-selector__swatch--nord {
+  background: linear-gradient(135deg, #2e3440 50%, #88c0d0 50%);
+}
+
+.theme-selector__swatch--dracula {
+  background: linear-gradient(135deg, #282a36 50%, #bd93f9 50%);
+}


### PR DESCRIPTION
## Summary
- カラーテーマ切り替え機能を追加
- 5テーマ対応: Light, Dark, Solarized Light, Nord, Dracula
- CSS変数ベースのテーマシステム
- chrome.storage.local でテーマ設定を保存

## Changes
### 新規ファイル
- `themes.css`: 5テーマのCSS変数定義

### 変更ファイル
- `theme.js`: テーマ管理ロジック（load/set/UI生成）
- `popup.css`: CSS変数を使用するように変更
- `popup.html`: themes.css読み込み、テーマセレクターUI追加
- `popup.js`: テーマ初期化
- `preview.html`: themes.css読み込み、テーマセレクターUI追加
- `preview.js`: テーマ初期化

## Test plan
- [ ] テーマドロップダウンで5テーマが選択可能
- [ ] テーマ切り替えが即座に反映される
- [ ] ポップアップを閉じて再度開いても選択したテーマが維持される
- [ ] プレビュー画面にもテーマが反映される
- [ ] 各テーマで文字が読みやすいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)