### PR TITLE
fix: resolve inline code double-escape and add persist-now

### DIFF
--- a/extension/src/auto-save.js
+++ b/extension/src/auto-save.js
@@ -68,13 +68,13 @@ export async function persistNow() {
     await persistState();
     setStatus("saved", "保存しました");
     statusResetTimeout = setTimeout(() => {
-      setStatus("idle");
+      setStatus("idle", "編集中");
     }, 1500);
   } catch (error) {
     console.error("即時保存に失敗:", error);
     setStatus("error", "保存に失敗しました");
     statusResetTimeout = setTimeout(() => {
-      setStatus("idle");
+      setStatus("idle", "編集中");
     }, 3000);
   }
 }

--- a/extension/src/auto-save.js
+++ b/extension/src/auto-save.js
@@ -47,3 +47,34 @@ export function scheduleAutoSave() {
     }
   }, AUTO_SAVE_DELAY);
 }
+
+/**
+ * 即時保存（タブを開く等の場面で使用）
+ * 遅延保存をキャンセルして即座に保存する
+ */
+export async function persistNow() {
+  // 既存のタイマーをクリア
+  if (autoSaveTimeout) {
+    clearTimeout(autoSaveTimeout);
+    autoSaveTimeout = null;
+  }
+  if (statusResetTimeout) {
+    clearTimeout(statusResetTimeout);
+    statusResetTimeout = null;
+  }
+
+  setStatus("saving", "保存中…");
+  try {
+    await persistState();
+    setStatus("saved", "保存しました");
+    statusResetTimeout = setTimeout(() => {
+      setStatus("idle");
+    }, 1500);
+  } catch (error) {
+    console.error("即時保存に失敗:", error);
+    setStatus("error", "保存に失敗しました");
+    statusResetTimeout = setTimeout(() => {
+      setStatus("idle");
+    }, 3000);
+  }
+}

--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -28,7 +28,7 @@ import {
 import { elements } from "./dom.js";
 import { renderNoteList, updateEditor, setStatus, updateActiveNoteMeta } from "./render.js";
 import { renderPreviewPanel } from "./preview_panel.js";
-import { scheduleAutoSave } from "./auto-save.js";
+import { scheduleAutoSave, persistNow } from "./auto-save.js";
 import {
   handleListTab,
   handleListBackspace,
@@ -249,7 +249,13 @@ function handleSortToggle() {
 // ナビゲーションハンドラ
 // ─────────────────────────────────────────────────────────────────
 
-function handlePreviewOpen() {
+async function handlePreviewOpen() {
+  // タブ側は拡張の保存領域から直接ロードするため、最新状態を先に保存してから開く
+  try {
+    await persistNow();
+  } catch (error) {
+    console.error("タブを開く前の保存に失敗しました", error);
+  }
   const url = chrome.runtime.getURL("src/preview.html");
   openInNewTab(url, "プレビューを開けませんでした");
 }

--- a/extension/src/events.js
+++ b/extension/src/events.js
@@ -251,11 +251,7 @@ function handleSortToggle() {
 
 async function handlePreviewOpen() {
   // タブ側は拡張の保存領域から直接ロードするため、最新状態を先に保存してから開く
-  try {
-    await persistNow();
-  } catch (error) {
-    console.error("タブを開く前の保存に失敗しました", error);
-  }
+  await persistNow();
   const url = chrome.runtime.getURL("src/preview.html");
   openInNewTab(url, "プレビューを開けませんでした");
 }

--- a/extension/src/markdown.js
+++ b/extension/src/markdown.js
@@ -28,10 +28,27 @@ export function renderMarkdown(text) {
       .replace(/>/g, "&gt;");
 
   const formatInline = (str) => {
-    let escaped = escapeHtml(str);
-    escaped = escaped.replace(/`([^`]+)`/g, (_, code) => `<code>${escapeHtml(code)}</code>`);
+    const codeSpans = [];
+    const placeholderPrefix = "@@INLINE_CODE_SPAN_";
+    const placeholderSuffix = "@@";
+
+    // 1. コードスパンをプレースホルダーに置換して退避
+    const processed = String(str || "").replace(/`([^`]+)`/g, (_, code) => {
+      const idx = codeSpans.length;
+      codeSpans.push(String(code ?? ""));
+      return `${placeholderPrefix}${idx}${placeholderSuffix}`;
+    });
+
+    // 2. エスケープと他のインライン書式処理
+    let escaped = escapeHtml(processed);
     escaped = escaped.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
     escaped = escaped.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+
+    // 3. プレースホルダーを実際のcodeタグに復元
+    for (let i = 0; i < codeSpans.length; i++) {
+      const token = `${placeholderPrefix}${i}${placeholderSuffix}`;
+      escaped = escaped.replaceAll(token, `<code>${escapeHtml(codeSpans[i])}</code>`);
+    }
     return escaped;
   };
 


### PR DESCRIPTION
## Summary
- 旧PR #11 の修正内容を現在のコードベースに再実装
- インラインコードの二重エスケープ問題を修正
- プレビュータブを開く前に即時保存する機能を追加

## Changes
### markdown.js
- formatInline()でプレースホルダー方式を採用
- コードスパンを先に退避し、エスケープ後に復元

### auto-save.js
- persistNow()関数を追加（即時保存用）
- 遅延保存タイマーをキャンセルして即座に保存

### events.js
- handlePreviewOpen()でpersistNow()を呼び出し
- プレビューを開く前に最新状態を保存

## Test plan
- [ ] インラインコード内の `<` `>` が正しく表示される
- [ ] プレビュータブを開くと最新の編集内容が反映される
- [ ] 自動保存が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)