### PR TITLE
fix: improve button visibility across all themes

### DIFF
--- a/extension/src/popup.css
+++ b/extension/src/popup.css
@@ -337,8 +337,8 @@ body {
 }
 
 .button--ghost:hover {
-  background: rgba(148, 163, 184, 0.12);
-  border-color: rgba(148, 163, 184, 0.5);
+  background: var(--btn-ghost-hover-bg);
+  border-color: var(--border-color-input);
 }
 
 .button--ghost:active {
@@ -465,7 +465,7 @@ body {
   background: transparent;
   padding: 6px;
   border-radius: 6px;
-  color: #64748b;
+  color: var(--icon-color);
   cursor: pointer;
   transition: background 0.2s ease, color 0.2s ease;
 }
@@ -475,8 +475,8 @@ body {
 }
 
 .icon-button:hover {
-  background: rgba(100, 116, 139, 0.12);
-  color: #ef4444;
+  background: var(--icon-hover-bg);
+  color: var(--icon-hover-color);
 }
 
 .icon-button:active {
@@ -492,11 +492,11 @@ body {
   height: 42px;
   display: grid;
   place-items: center;
-  box-shadow: 0 10px 22px rgba(37, 99, 235, 0.16);
+  box-shadow: var(--shadow-soft);
 }
 
 .icon-button--primary:hover {
-  background: rgba(37, 99, 235, 0.24);
+  background: var(--bg-button-hover);
 }
 
 .editor__status {
@@ -651,9 +651,9 @@ body {
 
 
 .copy-button {
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  background: rgba(255, 255, 255, 0.03);
-  color: rgba(226, 232, 240, 0.9);
+  border: 1px solid var(--btn-copy-border);
+  background: var(--btn-copy-bg);
+  color: var(--btn-copy-text);
   border-radius: 8px;
   padding: 6px 10px;
   font-size: 12px;
@@ -670,8 +670,8 @@ body {
 }
 
 .copy-button:hover {
-  background: rgba(148, 163, 184, 0.15);
-  border-color: rgba(148, 163, 184, 0.5);
+  background: var(--btn-ghost-hover-bg);
+  border-color: var(--border-color-input);
 }
 
 .segmented {

--- a/extension/src/themes.css
+++ b/extension/src/themes.css
@@ -30,6 +30,14 @@
   --success-color: #22c55e;
   --shadow: 0 24px 50px rgba(15, 23, 42, 0.16);
   --shadow-soft: 0 10px 28px rgba(15, 23, 42, 0.08);
+  /* Button visibility */
+  --icon-color: #4a5568;
+  --icon-hover-color: #ef4444;
+  --icon-hover-bg: rgba(100, 116, 139, 0.12);
+  --btn-ghost-hover-bg: rgba(148, 163, 184, 0.12);
+  --btn-copy-bg: rgba(15, 23, 42, 0.06);
+  --btn-copy-text: #334155;
+  --btn-copy-border: rgba(15, 23, 42, 0.15);
 }
 
 [data-theme="dark"] {
@@ -60,6 +68,14 @@
   --success-color: #4ade80;
   --shadow: 0 24px 50px rgba(0, 0, 0, 0.35);
   --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.22);
+  /* Button visibility */
+  --icon-color: #9ca3af;
+  --icon-hover-color: #f87171;
+  --icon-hover-bg: rgba(156, 163, 175, 0.15);
+  --btn-ghost-hover-bg: rgba(148, 163, 184, 0.12);
+  --btn-copy-bg: rgba(255, 255, 255, 0.06);
+  --btn-copy-text: #e2e8f0;
+  --btn-copy-border: rgba(148, 163, 184, 0.25);
 }
 
 [data-theme="solarized-light"] {
@@ -90,6 +106,14 @@
   --success-color: #859900;
   --shadow: 0 24px 50px rgba(101, 123, 131, 0.15);
   --shadow-soft: 0 10px 28px rgba(101, 123, 131, 0.1);
+  /* Button visibility */
+  --icon-color: #586e75;
+  --icon-hover-color: #dc322f;
+  --icon-hover-bg: rgba(88, 110, 117, 0.12);
+  --btn-ghost-hover-bg: rgba(101, 123, 131, 0.12);
+  --btn-copy-bg: rgba(88, 110, 117, 0.08);
+  --btn-copy-text: #586e75;
+  --btn-copy-border: rgba(88, 110, 117, 0.2);
 }
 
 [data-theme="nord"] {
@@ -120,6 +144,14 @@
   --success-color: #a3be8c;
   --shadow: 0 24px 50px rgba(0, 0, 0, 0.4);
   --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.3);
+  /* Button visibility */
+  --icon-color: #d8dee9;
+  --icon-hover-color: #bf616a;
+  --icon-hover-bg: rgba(136, 192, 208, 0.15);
+  --btn-ghost-hover-bg: rgba(136, 192, 208, 0.12);
+  --btn-copy-bg: rgba(216, 222, 233, 0.08);
+  --btn-copy-text: #eceff4;
+  --btn-copy-border: rgba(216, 222, 233, 0.2);
 }
 
 [data-theme="dracula"] {
@@ -150,6 +182,14 @@
   --success-color: #50fa7b;
   --shadow: 0 24px 50px rgba(0, 0, 0, 0.5);
   --shadow-soft: 0 10px 28px rgba(0, 0, 0, 0.35);
+  /* Button visibility */
+  --icon-color: #f8f8f2;
+  --icon-hover-color: #ff5555;
+  --icon-hover-bg: rgba(189, 147, 249, 0.15);
+  --btn-ghost-hover-bg: rgba(189, 147, 249, 0.12);
+  --btn-copy-bg: rgba(248, 248, 242, 0.08);
+  --btn-copy-text: #f8f8f2;
+  --btn-copy-border: rgba(98, 114, 164, 0.3);
 }
 
 /* Theme Selector Styles */


### PR DESCRIPTION
## Summary
- Fix button visibility issues across all themes
- Replace hardcoded colors with CSS variables for consistent theming

## Problem
Buttons appeared washed out or invisible in certain themes due to hardcoded colors.

## Solution
Added theme-specific CSS variables for buttons:

### themes.css (new variables for each theme)
- `--icon-color`: Icon button default color
- `--icon-hover-color`: Icon button hover color
- `--icon-hover-bg`: Icon button hover background
- `--btn-ghost-hover-bg`: Ghost button hover background
- `--btn-copy-bg`: Copy button background
- `--btn-copy-text`: Copy button text color
- `--btn-copy-border`: Copy button border

### popup.css (updated selectors)
- `.icon-button`: Use `var(--icon-color)`
- `.icon-button:hover`: Use `var(--icon-hover-bg)`, `var(--icon-hover-color)`
- `.button--ghost:hover`: Use `var(--btn-ghost-hover-bg)`
- `.copy-button`: Use `var(--btn-copy-bg)`, `var(--btn-copy-text)`, `var(--btn-copy-border)`
- `.icon-button--primary`: Use `var(--shadow-soft)`, `var(--bg-button-hover)`

## Test plan
- [ ] Light theme: all buttons clearly visible
- [ ] Dark theme: all buttons clearly visible
- [ ] Solarized Light: all buttons clearly visible
- [ ] Nord: all buttons clearly visible
- [ ] Dracula: all buttons clearly visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)